### PR TITLE
Fix the demo for Chrome 45.

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -91,7 +91,7 @@ function subscribeDevice() {
 
   // We need the service worker registration to access the push manager
   navigator.serviceWorker.ready.then(function(serviceWorkerRegistration) {
-    serviceWorkerRegistration.pushManager.subscribe()
+    serviceWorkerRegistration.pushManager.subscribe({ userVisibleOnly: true })
       .then(onPushSubscription)
       .catch(function(e) {
         // Check for a permission prompt issue


### PR DESCRIPTION
Chrome 45 has removed support for the "gcm_user_visible_only" Manifest
key, and now instead requires the developer to specify their intention
of only displaying user visible notifications in the call to
PushManager.subscribe():

serviceWorkerRegistration.pushManager.subscribe({
    userVisibleOnly: true
}).then(...)

This deprecation was announced on blink-dev@chromium.org, and can be
seen on ChromeStatus.com as well:

https://www.chromestatus.com/feature/5778950739460096