### PR TITLE
fix link for encryption-test.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
         <span class="mdl-layout-title">Push Demo</span>
         <div class="mdl-layout-spacer"></div>
         <nav class="mdl-navigation mdl-layout--large-screen-only">
-          <a class="mdl-navigation__link" href="/encryption-test.html">Encryption Tests</a>
+          <a class="mdl-navigation__link" href="encryption-test.html">Encryption Tests</a>
           <a class="mdl-navigation__link" href="https://github.com/gauntface/simple-push-demo">Github</a>
           <a class="mdl-navigation__link" href="https://developers.google.com/web/fundamentals/primers/push-notifications/">Docs</a>
           <a class="mdl-navigation__link" href="https://developers.google.com/web/fundamentals/getting-started/push-notifications/">Guide</a>


### PR DESCRIPTION
The heading `/` containing link would redirect to `https://gauntface.github.io/encryption-test.html` so I removed the heading slash.