### PR TITLE
DOC(README) display demo image instead of its link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To try out the demo locally, clone the repo and run the following:
 
         gulp dev
 
-[Imgur](http://i.imgur.com/Y2yafBv.png)
+<img src="http://i.imgur.com/Y2yafBv.png" width="304px" height="366xpx" />
 
 The two methods you can send a push message to your device after enabling it are:
 


### PR DESCRIPTION
It was probably intended to be as it is but I thought it would be better to display the demo directly instead of a non-explicit link.