### PR TITLE
Add TTL header to the curl command

### DIFF
--- a/src/scripts/app-controller.js
+++ b/src/scripts/app-controller.js
@@ -212,7 +212,7 @@ export default class AppController {
 
   produceWebPushProtocolCURLCommand(subscription) {
     var curlEndpoint = subscription.endpoint;
-    var curlCommand = 'curl --request POST ' + curlEndpoint;
+    var curlCommand = 'curl -H "TTL: 60" --request POST ' + curlEndpoint;
     return curlCommand;
   }
 


### PR DESCRIPTION
The TTL header is required: https://github.com/webpush-wg/webpush-protocol/pull/77.