### PR TITLE
Add TTL header when sending a request to a standard Web Push service

### DIFF
--- a/src/scripts/app-controller.js
+++ b/src/scripts/app-controller.js
@@ -183,7 +183,10 @@ export default class AppController {
     console.log('Sending XHR to Web Push Protocol endpoint');
 
     fetch(subscription.endpoint, {
-      method: 'post'
+      method: 'post',
+      headers: {
+        'TTL': '60',
+      },
     })
     .then(function(response) {
       if (response.status >= 400 && response.status < 500) {

--- a/src/scripts/app-controller.js
+++ b/src/scripts/app-controller.js
@@ -185,8 +185,8 @@ export default class AppController {
     fetch(subscription.endpoint, {
       method: 'post',
       headers: {
-        TTL: '60',
-      },
+        TTL: '60'
+      }
     })
     .then(function(response) {
       if (response.status >= 400 && response.status < 500) {

--- a/src/scripts/app-controller.js
+++ b/src/scripts/app-controller.js
@@ -185,7 +185,7 @@ export default class AppController {
     fetch(subscription.endpoint, {
       method: 'post',
       headers: {
-        'TTL': '60',
+        TTL: '60',
       },
     })
     .then(function(response) {


### PR DESCRIPTION
The TTL header is required: webpush-wg/webpush-protocol#77.