### PR TITLE
Using JSON.stringify on curlCommand

### DIFF
--- a/src/scripts/app-controller.js
+++ b/src/scripts/app-controller.js
@@ -234,7 +234,7 @@ class AppController {
         bodyFormat.textContent = 'String';
         bodyContent.textContent = requestInfo.body;
 
-        curlCommand += ` -d "${requestInfo.body}"`;
+        curlCommand += ` -d ${JSON.stringify(requestInfo.body)}`;
       } else {
         bodyFormat.textContent = 'No Body';
         bodyContent.textContent = 'N/A';


### PR DESCRIPTION
on terminal, I've got an error with this data

```
-d "{"to":"e7_wo1X9cOM:APA91bE4rC2aj_23zkiKvu-aDD0EXZErtkWSNlGEWETpqie9sqWrPwea6K2Ol1brhctka2hmTqLmoDBR-7hqUPJ3gB5hUHg44rN6Q_W5WeDdRsK7_mHD6P9PVMkV614fdRt5TY_vGi0l"}"
```

It's related to escape character. I just call `JSON.stringify` without consideration of mime type

````
-d "{\"to\":\"e7_wo1X9cOM:APA91bE4rC2aj_23zkiKvu-aDD0EXZErtkWSNlGEWETpqie9sqWrPwea6K2Ol1brhctka2hmTqLmoDBR-7hqUPJ3gB5hUHg44rN6Q_W5WeDdRsK7_mHD6P9PVMkV614fdRt5TY_vGi0l\"}"
```