### PR TITLE
Fix typo in README for "aes128gcm"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -66,7 +66,7 @@
 
           <h4>Supported Content Encodings </h4>
           <p>A change to the web push spec moves browsers from "aesgcm" to
-            "aesgcm128" content encoding.</p>
+            "aes128gcm" content encoding.</p>
           <p>To determine which is supported the current browser you can view
             <code>PushManager.supportedContentEncodings</code>.</p>
 


### PR DESCRIPTION
Changed "aesgcm128" to "aes128gcm "