### PR TITLE
Update notes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -112,8 +112,7 @@
       <p><strong>Browser Notes:</strong></p>
 
       <ul>
-        <li>Not seeing a notification in Firefox? <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1233086" target="_blank">This bug may be the culprit.</a> Check the logs for a note when the push is received though.</li>
-        <li>Opera supports push on Android, but not on desktop and there is no feature detect for this. :( Bug has been filed on their private issue tracker.</li>
+        <li>On iOS and iPadOS, to request permission to receive push notifications, web apps must first be added to the Home Screen. The user can <a href="https://support.apple.com/HT201925" target="_blank">manage those permissions per web app</a> in Notifications Settings.</li>
       </ul>
 
       <p><strong>Further reading:</strong></p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,11 @@
   </header>
 
   <main class="l-main">
+    <p>On iOS and iPadOS, to request permission to receive push notifications,
+    web apps must first be added to the Home Screen. The user can
+    <a href="https://support.apple.com/HT201925" target="_blank">manage those
+    permissions per web app</a> in Notifications Settings.</p>
+
     <div class="l-enable">
       <div class="c-toggle">
         <input class="c-toggle--checkbox js-enable-checkbox" type="checkbox" id="enable-push-switch" disabled />
@@ -99,13 +104,6 @@
 
           <hr />
         </div>
-
-        <p><strong>Notes:</strong></p>
-
-        <ul>
-          <li>Not seeing a notification in Firefox? <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1233086" target="_blank">This bug may be the culprit.</a> Check the logs for a note when the push is received though.</li>
-          <li>Opera supports push on Android, but not on desktop and there is no feature detect for this. :( Bug has been filed on their private issue tracker.</li>
-        </ul>
 
         <p><strong>Further reading:</strong></p>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,11 +26,6 @@
   </header>
 
   <main class="l-main">
-    <p>On iOS and iPadOS, to request permission to receive push notifications,
-    web apps must first be added to the Home Screen. The user can
-    <a href="https://support.apple.com/HT201925" target="_blank">manage those
-    permissions per web app</a> in Notifications Settings.</p>
-
     <div class="l-enable">
       <div class="c-toggle">
         <input class="c-toggle--checkbox js-enable-checkbox" type="checkbox" id="enable-push-switch" disabled />
@@ -104,6 +99,13 @@
 
           <hr />
         </div>
+
+        <p><strong>Notes:</strong></p>
+
+        <ul>
+          <li>Not seeing a notification in Firefox? <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1233086" target="_blank">This bug may be the culprit.</a> Check the logs for a note when the push is received though.</li>
+          <li>Opera supports push on Android, but not on desktop and there is no feature detect for this. :( Bug has been filed on their private issue tracker.</li>
+        </ul>
 
         <p><strong>Further reading:</strong></p>
 

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -18,7 +18,6 @@ self.addEventListener('push', function(event) {
 		body: 'Thanks for sending this push msg.',
 		icon: './images/logo-192x192.png',
 		badge: './images/badge-72x72.png',
-		tag: 'simple-push-demo-notification',
 		data: {
 			url: 'https://web.dev/push-notifications-overview/',
 		},

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -18,6 +18,7 @@ self.addEventListener('push', function(event) {
 		body: 'Thanks for sending this push msg.',
 		icon: './images/logo-192x192.png',
 		badge: './images/badge-72x72.png',
+		tag: 'simple-push-demo-notification',
 		data: {
 			url: 'https://web.dev/push-notifications-overview/',
 		},

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -13,7 +13,6 @@ self.addEventListener('push', function(event) {
 		body: 'Thanks for sending this push msg.',
 		icon: './images/logo-192x192.png',
 		badge: './images/badge-72x72.png',
-		tag: 'simple-push-demo-notification',
 		data: {
 			url: 'https://web.dev/push-notifications-overview/',
 		},


### PR DESCRIPTION
Web push notifications are available for web apps on iOS and iPadOS since version 16.4 beta 1 (official announcement: https://webkit.org/blog/13878/web-push-for-web-apps-on-ios-and-ipados/).

This pull request:

* adds a note about iOS and iPadOS
* removes obsolete notes
* removes the `tag` from notifications to avoid confusing users why "notifications sometimes don't display" :)