### PR TITLE
Add Meta Quest Browser support

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -26,6 +26,7 @@ app.post('/api/v3/sendpush', async function(request, res) {
 		httpsOptions.hostname = urlParts.hostname;
 		httpsOptions.port = urlParts.port;
 		httpsOptions.path = urlParts.pathname;
+		httpsOptions.search = urlParts.search;
 
 		const pushRequest = https.request(httpsOptions, function(pushResponse) {
 			let responseText = '';

--- a/api/index.js
+++ b/api/index.js
@@ -18,17 +18,13 @@ app.use(function(req, res, next) {
 app.post('/api/v3/sendpush', async function(request, res) {
 	try {
 		const requestData = request.body;
-		const httpsOptions = {
+		const url = requestData.endpoint;
+		const options = {
 			headers: requestData.headers,
 			method: 'POST',
 		};
-		const urlParts = new URL(requestData.endpoint);
-		httpsOptions.hostname = urlParts.hostname;
-		httpsOptions.port = urlParts.port;
-		httpsOptions.path = urlParts.pathname;
-		httpsOptions.search = urlParts.search;
 
-		const pushRequest = https.request(httpsOptions, function(pushResponse) {
+		const pushRequest = https.request(url, options, function(pushResponse) {
 			let responseText = '';
 
 			pushResponse.on('data', function(chunk) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -103,7 +103,7 @@
 
     <div class="c-error-msg js-error-message-container u-hidden">
       <h1 class="c-error-msg--title js-error-title"></h1>
-      <p class="js-error-message"></p>
+      <pre><code class="js-error-message"></code></pre>
 
       <hr />
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,7 @@
 
       <ul>
         <li>On iOS and iPadOS, to request permission to receive push notifications, web apps must first be added to the Home Screen. The user can <a href="https://support.apple.com/HT201925" target="_blank">manage those permissions per web app</a> in Notifications Settings.</li>
+        <li>On Meta Quest, to request permission to receive push notifications, web apps must be <a href="https://web.dev/pwas-on-oculus-2/#packaging-pwas-with-pwabuilder" target="_blank">packaged</a>.</li>
       </ul>
 
       <p><strong>Further reading:</strong></p>


### PR DESCRIPTION
This pull request fixes sending web push notifications to endpoints used in Meta Quest Browser, such as https://graph.facebook.com/rl_push_send?notif_token=1525031671638599, which have search params.