### PR TITLE
Prefer 'aes128gcm' over 'aesgcm'

### DIFF
--- a/frontend/scripts/encryption/encryption-factory.js
+++ b/frontend/scripts/encryption/encryption-factory.js
@@ -24,10 +24,10 @@ export class EncryptionFactory {
 		const encodings = this.supportedEncodings();
 		for (const e of encodings) {
 			switch (e) {
-			case 'aesgcm':
-				return new EncryptionAESGCM();
 			case 'aes128gcm':
 				return new EncryptionAES128GCM();
+			case 'aesgcm':
+				return new EncryptionAESGCM();
 			default:
 				console.warn(`Unknown content encoding: ${e}`);
 			}


### PR DESCRIPTION
Safari supports both, `aes128gcm` and `aesgcm`. This pull request allows this demo to use `aes128gcm` instead of `aesgcm` in Safari on macOS.